### PR TITLE
Only intercept submissions of forms with a scope

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -180,11 +180,10 @@ pw_Component.prototype = {
 
     // make it mutable
     var mutableCb = function (evt) {
-      evt.preventDefault();
-
       var scope = pw.node.scope(evt.target);
 
       if (scope) {
+        evt.preventDefault();
         self.mutated(scope);
       }
     };


### PR DESCRIPTION
Before this change, the submission of any form with a `data-ui` attribute was intercepted and prevented, and then if the form also had a scope a mutation event was fired on that scope. So if the form had a
scope you could listen for the mutation event in your component and submit the form from there. That worked, but it meant forms without a scope were unsubmittable. This change fixes it so that we only prevent the submission if the form has a scope, which allows unscoped forms to be submitted normally.