### PR TITLE
Add broadcast to indicate window.socket is available

### DIFF
--- a/src/core/socket.js
+++ b/src/core/socket.js
@@ -6,6 +6,7 @@ pw.init.register(function () {
   pw.socket.init({
     cb: function (socket) {
       window.socket = socket;
+      pw.component.broadcast('socket:available');
     }
   });
 });


### PR DESCRIPTION
I've hit a case where I need to send a websocket request as soon as my component is initialized, but I can't count on the socket having been configed and added to `window` in time. This change will let me listen for the `socket:available` broadcast and use that to trigger my request instead of using `setTimeout` to wait a second.