### PR TITLE
Fix an issue setting values for attrs like `class`

### DIFF
--- a/src/core/node.js
+++ b/src/core/node.js
@@ -331,7 +331,11 @@ pw.node = {
       }
 
       if (v) {
-        if (v instanceof Array) {
+        // handles the case where the attribute value was a lambda
+        // that alters the value; we have to check one level in for
+        // an instruction set because values for attributes such as
+        // `class` will also be arrays
+        if (v instanceof Array && v[0] instanceof Array) {
           v.forEach(function (attrInstruction) {
             nAtrs[attrInstruction[0]](attr, attrInstruction[1]);
           });


### PR DESCRIPTION
The value of such attributes will be an array. This was causing an issue in some code that was checking for nested instruction sets. To fix, we not only check that the value is an array, but also check for a nested array (which implies that it is, in fact, an instruction set).