### PR TITLE
check for empty string when binding value to node

### DIFF
--- a/src/core/node.js
+++ b/src/core/node.js
@@ -363,7 +363,7 @@ pw.node = {
     } else if (node.tagName === 'TEXTAREA' || pw.node.isSelfClosingTag(node)) {
       node.value = value;
     } else {
-      if (value) {
+      if (value || value === '') {
         node.innerHTML = value;
       }
     }


### PR DESCRIPTION
There was an issue that the empty string acts as false in condition.